### PR TITLE
[Feat] Layout Auth Page

### DIFF
--- a/src/components/AuthPage/AuthTab.tsx
+++ b/src/components/AuthPage/AuthTab.tsx
@@ -1,9 +1,25 @@
+import { Link } from "react-router-dom";
+import "./style/authTab.css"
+
 export default function AuthTab() {
-  const authTabArray = ["로그인", "회원가입"];
+  const authTabArray = [
+    {
+      tabTitle: "로그인",
+      tabNavigate: "/auth/login",
+    },
+    {
+      tabTitle: "회원가입",
+      tabNavigate: "/auth/signup",
+    },
+  ];
   return (
     <>
       {authTabArray.map((element) => {
-        return <li key={element}>{element}</li>;
+        return (
+          <Link to={element.tabNavigate}>
+            <li className="Auth_List" key={element.tabTitle}>{element.tabTitle}</li>
+          </Link>
+        );
       })}
     </>
   );

--- a/src/components/AuthPage/AuthTab.tsx
+++ b/src/components/AuthPage/AuthTab.tsx
@@ -1,0 +1,10 @@
+export default function AuthTab() {
+  const authTabArray = ["로그인", "회원가입"];
+  return (
+    <>
+      {authTabArray.map((element) => {
+        return <li key={element}>{element}</li>;
+      })}
+    </>
+  );
+}

--- a/src/components/AuthPage/AuthTab.tsx
+++ b/src/components/AuthPage/AuthTab.tsx
@@ -16,8 +16,8 @@ export default function AuthTab() {
     <>
       {authTabArray.map((element) => {
         return (
-          <Link to={element.tabNavigate}>
-            <li className="Auth_List" key={element.tabTitle}>{element.tabTitle}</li>
+          <Link key={element.tabTitle} to={element.tabNavigate}>
+            <li className="Auth_List">{element.tabTitle}</li>
           </Link>
         );
       })}

--- a/src/components/AuthPage/style/authTab.css
+++ b/src/components/AuthPage/style/authTab.css
@@ -1,0 +1,3 @@
+.Auth_List{
+  font-size: 20px;
+}

--- a/src/components/common/CommonInput.tsx
+++ b/src/components/common/CommonInput.tsx
@@ -1,6 +1,6 @@
 import { ChangeEventHandler } from "react";
 import styled from "styled-components";
-import "./Style/commonInput.css";
+// import "./Style/commonInput.css"; 추후 적용예정
 
 interface InputProps {
   width?: string;

--- a/src/components/common/CommonInput.tsx
+++ b/src/components/common/CommonInput.tsx
@@ -1,6 +1,6 @@
 import { ChangeEventHandler } from "react";
 import styled from "styled-components";
-// import "./Style/commonInput.css"; 추후 적용예정
+import "./style/commonInput.css"
 
 interface InputProps {
   width?: string;
@@ -8,7 +8,7 @@ interface InputProps {
   value: string;
   onChange: ChangeEventHandler<HTMLInputElement>;
   type: "text" | "password" | "email";
-  placeholder: string
+  placeholder: string;
   radius?: string;
   label?: string;
   name?: string;
@@ -28,19 +28,19 @@ const Input = styled.input<InputProps>`
 export default function CommonInput(props: InputProps) {
   return (
     <div className="Input_Container">
-      <label className="Input_Label">
-        {props.label}
-      </label>
-      <Input
-        name={props.name}
-        radius={props.radius}
-        placeholder={props.placeholder}
-        type={props.type}
-        value={props.value}
-        onChange={props.onChange}
-        width={props.width}
-        height={props.height}
-      />
+      <label className="Input_Label">{props.label}</label>
+      <div className="Common_Input_Wrapper">
+        <Input
+          name={props.name}
+          radius={props.radius}
+          placeholder={props.placeholder}
+          type={props.type}
+          value={props.value}
+          onChange={props.onChange}
+          width={props.width}
+          height={props.height}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/common/CustomButton.tsx
+++ b/src/components/common/CustomButton.tsx
@@ -1,0 +1,31 @@
+import { ButtonHTMLAttributes } from "react";
+import styled from "styled-components";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  width: string;
+  height: string;
+  contents: string;
+}
+
+const CommonButton = styled.button<ButtonProps>`
+  display: flex;
+  justify-content: center;
+  width: ${(props) => (props.width ? props.width : {})};
+  height: ${(props) => (props.width ? props.height : {})};
+  border-radius: 15px;
+  font-size: 18px;
+  border: none;
+  color: white;
+  padding: 10px;
+  background-color: #619bf2;
+  box-shadow: 1px 1px 1px 1px #7695c34a;
+  &:hover {
+    background-color: #477ac8;
+  }
+`;
+
+export default function CustomButton(props: ButtonProps) {
+  return <CommonButton {...props}>
+    {props.contents}
+  </CommonButton>;
+}

--- a/src/components/common/style/commonInput.css
+++ b/src/components/common/style/commonInput.css
@@ -1,0 +1,8 @@
+.Input_Container{
+  display: flex;
+  flex-direction: column;
+}
+
+.Input_Label{
+  margin-bottom: 10px;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -10,4 +10,5 @@ li {
 
 a {
   text-decoration: none;
+  color: black;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,7 @@ a {
   text-decoration: none;
   color: black;
 }
+
+button {
+  cursor: pointer;
+}

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,5 +1,7 @@
+import { Outlet } from "react-router-dom";
 import styled from "styled-components";
 import AuthTab from "../components/AuthPage/AuthTab";
+import "./style/authPage.css";
 
 const AuthWrapper = styled.div`
   display: flex;
@@ -11,9 +13,12 @@ const AuthWrapper = styled.div`
 export default function AuthPage() {
   return (
     <AuthWrapper>
-      <ul>
-        <AuthTab />
-      </ul>
+      <div>
+        <ul className="Auth_Tab_Wrapper">
+          <AuthTab />
+        </ul>
+      </div>
+      <Outlet />
     </AuthWrapper>
   );
 }

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -1,3 +1,19 @@
-export default function AuthPage(){
-  return(<></>)
+import styled from "styled-components";
+import AuthTab from "../components/AuthPage/AuthTab";
+
+const AuthWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  height: 94.7vh;
+`;
+
+export default function AuthPage() {
+  return (
+    <AuthWrapper>
+      <ul>
+        <AuthTab />
+      </ul>
+    </AuthWrapper>
+  );
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,14 +3,13 @@ import { AuthContent } from "./SignUp";
 
 export default function Login() {
   return (
-    // 컴포넌트화 시킬예정
     <AuthContent>
       <div>
         <h2>로그인</h2>
       </div>
       <div className="Input_Wrapper">
         <CommonInput
-          width="490px"
+          width={window.innerWidth <= 390 ? "320px" : "490px"}
           height="34px"
           radius="3px"
           value={""}
@@ -20,7 +19,7 @@ export default function Login() {
           placeholder={""}
         />
         <CommonInput
-          width="490px"
+          width={window.innerWidth <= 390 ? "320px" : "490px"}
           height="34px"
           radius="3px"
           value={""}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -17,7 +17,7 @@ export default function Login() {
           label={"닉네임"}
           onChange={() => {}}
           type={"text"}
-          placeholder={""}
+          placeholder={"닉네임을 입력해주세요"}
         />
         <CommonInput
           width={window.innerWidth <= 390 ? "320px" : "490px"}
@@ -27,7 +27,7 @@ export default function Login() {
           label={"비밀번호"}
           onChange={() => {}}
           type={"password"}
-          placeholder={""}
+          placeholder={"비밀번호를 입력해주세요"}
         />
       </div>
       <div className="SignUp_Button_Wrapper">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,3 +1,39 @@
-export default function Login(){
-  return(<></>)
+import CommonInput from "../components/common/CommonInput";
+import { AuthContent } from "./SignUp";
+
+export default function Login() {
+  return (
+    // 컴포넌트화 시킬예정
+    <AuthContent>
+      <div>
+        <h2>로그인</h2>
+      </div>
+      <div className="Input_Wrapper">
+        <CommonInput
+          width="490px"
+          height="34px"
+          radius="3px"
+          value={""}
+          label={"닉네임"}
+          onChange={() => {}}
+          type={"text"}
+          placeholder={""}
+        />
+        <CommonInput
+          width="490px"
+          height="34px"
+          radius="3px"
+          value={""}
+          label={"비밀번호"}
+          onChange={() => {}}
+          type={"password"}
+          placeholder={""}
+        />
+      </div>
+      <div className="SignUp_Button_Wrapper">
+        {/* 추후 공용 Button으로 변경 예정 */}
+        <button>로그인</button>
+      </div>
+    </AuthContent>
+  );
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,5 @@
 import CommonInput from "../components/common/CommonInput";
+import CustomButton from "../components/common/CustomButton";
 import { AuthContent } from "./SignUp";
 
 export default function Login() {
@@ -30,8 +31,7 @@ export default function Login() {
         />
       </div>
       <div className="SignUp_Button_Wrapper">
-        {/* 추후 공용 Button으로 변경 예정 */}
-        <button>로그인</button>
+        <CustomButton width={"120px"} height={"41px"} contents={"로그인"} />
       </div>
     </AuthContent>
   );

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -51,7 +51,6 @@ export default function SignUp() {
         />
       </div>
       <div className="SignUp_Button_Wrapper">
-        {/* 추후 공용 Button으로 변경 예정 */}
         <CustomButton width={"120px"} height={"41px"} contents={"회원가입"} />
       </div>
     </AuthContent>

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -37,7 +37,7 @@ export default function SignUp() {
           label={"닉네임"}
           onChange={() => {}}
           type={"text"}
-          placeholder={""}
+          placeholder={"닉네임을 입력해주세요"}
         />
         <CommonInput
           width={window.innerWidth <= 390 ? "320px" : "490px"}
@@ -47,7 +47,7 @@ export default function SignUp() {
           label={"비밀번호"}
           onChange={() => {}}
           type={"password"}
-          placeholder={""}
+          placeholder={"비밀번호를 입력해주세요"}
         />
       </div>
       <div className="SignUp_Button_Wrapper">

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -15,6 +15,10 @@ export const AuthContent = styled.div`
   border: 1px solid 1px solid rgba(164, 164, 164, 0.153);
   margin-top: 50px;
   box-shadow: 3px 2px 5px rgba(164, 164, 164, 0.153);
+
+  @media (max-width: 390px) {
+    width: 360px;
+  }
 `;
 
 export default function SignUp() {
@@ -25,7 +29,7 @@ export default function SignUp() {
       </div>
       <div className="Input_Wrapper">
         <CommonInput
-          width="490px"
+          width={window.innerWidth <= 390 ? "320px" : "490px"}
           height="34px"
           radius="3px"
           value={""}
@@ -35,7 +39,7 @@ export default function SignUp() {
           placeholder={""}
         />
         <CommonInput
-          width="490px"
+          width={window.innerWidth <= 390 ? "320px" : "490px"}
           height="34px"
           radius="3px"
           value={""}

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,3 +1,40 @@
-export default function SignUp(){
-  return(<></>)
+import styled from "styled-components";
+import CommonInput from "../components/common/CommonInput";
+
+export const AuthContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 625px;
+  height: 670px;
+  padding: 20px 10px;
+  background-color: #ffffffcd;
+  margin-bottom: 40px;
+  border-radius: 10px;
+  border: 1px solid 1px solid rgba(164, 164, 164, 0.153);
+  justify-content: space-between;
+  margin-top: 50px;
+  box-shadow: 3px 2px 5px rgba(164, 164, 164, 0.153);
+`;
+
+export default function SignUp() {
+  return (
+    <AuthContent>
+      <div>
+        <h2>회원가입</h2>
+      </div>
+      <div>
+        <CommonInput
+          width="470px"
+          height="34px"
+          radius="3px"
+          value={""}
+          label={"닉네임"}
+          onChange={() => {}}
+          type={"text"}
+          placeholder={""}
+        />
+      </div>
+    </AuthContent>
+  );
 }

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import CommonInput from "../components/common/CommonInput";
+import "./style/signup.css";
 
 export const AuthContent = styled.div`
   display: flex;
@@ -12,7 +13,6 @@ export const AuthContent = styled.div`
   margin-bottom: 40px;
   border-radius: 10px;
   border: 1px solid 1px solid rgba(164, 164, 164, 0.153);
-  justify-content: space-between;
   margin-top: 50px;
   box-shadow: 3px 2px 5px rgba(164, 164, 164, 0.153);
 `;
@@ -23,9 +23,9 @@ export default function SignUp() {
       <div>
         <h2>회원가입</h2>
       </div>
-      <div>
+      <div className="Input_Wrapper">
         <CommonInput
-          width="470px"
+          width="490px"
           height="34px"
           radius="3px"
           value={""}
@@ -34,6 +34,20 @@ export default function SignUp() {
           type={"text"}
           placeholder={""}
         />
+        <CommonInput
+          width="490px"
+          height="34px"
+          radius="3px"
+          value={""}
+          label={"비밀번호"}
+          onChange={() => {}}
+          type={"password"}
+          placeholder={""}
+        />
+      </div>
+      <div className="SignUp_Button_Wrapper">
+        {/* 추후 공용 Button으로 변경 예정 */}
+        <button>회원가입</button>
       </div>
     </AuthContent>
   );

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import CommonInput from "../components/common/CommonInput";
+import CustomButton from "../components/common/CustomButton";
 import "./style/signup.css";
 
 export const AuthContent = styled.div`
@@ -51,7 +52,7 @@ export default function SignUp() {
       </div>
       <div className="SignUp_Button_Wrapper">
         {/* 추후 공용 Button으로 변경 예정 */}
-        <button>회원가입</button>
+        <CustomButton width={"120px"} height={"41px"} contents={"회원가입"} />
       </div>
     </AuthContent>
   );

--- a/src/pages/style/authPage.css
+++ b/src/pages/style/authPage.css
@@ -1,0 +1,16 @@
+.Auth_Tab_Wrapper {
+  display: flex;
+}
+
+.Auth_Tab_Wrapper > :first-child {
+  margin-right: 30px;
+}
+
+.Auth_Tab_Wrapper > li {
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.Auth_Tab_Wrapper{
+  margin-top: 40px;
+}

--- a/src/pages/style/authPage.css
+++ b/src/pages/style/authPage.css
@@ -1,5 +1,11 @@
 .Auth_Tab_Wrapper {
   display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: white;
+  width: 190px;
+  height: 30px;
+  border-radius: 5px;
 }
 
 .Auth_Tab_Wrapper > :first-child {

--- a/src/pages/style/signup.css
+++ b/src/pages/style/signup.css
@@ -1,0 +1,19 @@
+.Input_Wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 50%;
+}
+
+.Input_Wrapper > :last-child {
+  margin-top: 50px;
+}
+
+.SignUp_Button_Wrapper{
+  height: 30%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+}

--- a/src/pages/style/signup.css
+++ b/src/pages/style/signup.css
@@ -19,5 +19,5 @@
 }
 
 @media (max-width: 390px){
-  
+
 }

--- a/src/pages/style/signup.css
+++ b/src/pages/style/signup.css
@@ -17,3 +17,7 @@
   align-items: center;
   justify-content: flex-end;
 }
+
+@media (max-width: 390px){
+  
+}


### PR DESCRIPTION
# 제목

Auth Page의 기초 Layout 구현

## 변경 내용

* 추후 만들어질 Signup , Login Page의 부모 역할이 되는 Auth Page 레이아웃 설정
* Link로 인한 빠른 이동 및 각 이름에 맞는 이동링크를 구현
* Outlet으로 탭처럼 이동하는 페이지 구조 구현

![스크린샷 2023-04-04 오후 12 39 43](https://user-images.githubusercontent.com/99936345/229681269-b38302a3-6c7e-4eb0-88fa-5c177e9e1c63.png)
